### PR TITLE
Feature/#41 user shelf page

### DIFF
--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/DAO/BookRepository.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/DAO/BookRepository.java
@@ -4,10 +4,17 @@ import com.reactlibraryproject.springbootlibrary.Entity.Book;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
     Page<Book> findByTitleContaining(@RequestParam("title") String title, Pageable pageable);
 
     Page<Book> findByCategory(@RequestParam("category") String category, Pageable pageable);
+
+    @Query("SELECT b FROM Book b WHERE b.id IN :book_ids")
+    List<Book> findBooksByBookIds(@Param("book_ids") List<Long> bookId);
 }

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/ShelfCurrentLoansResponse.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/ShelfCurrentLoansResponse.java
@@ -1,0 +1,12 @@
+package com.reactlibraryproject.springbootlibrary.ReponseModels;
+
+import com.reactlibraryproject.springbootlibrary.Entity.Book;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ShelfCurrentLoansResponse {
+    private Book book;
+    private int daysLeft;
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Service/BookService.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Service/BookService.java
@@ -4,12 +4,15 @@ import com.reactlibraryproject.springbootlibrary.DAO.BookRepository;
 import com.reactlibraryproject.springbootlibrary.DAO.CheckoutRepository;
 import com.reactlibraryproject.springbootlibrary.Entity.Book;
 import com.reactlibraryproject.springbootlibrary.Entity.Checkout;
+import com.reactlibraryproject.springbootlibrary.ReponseModels.ShelfCurrentLoansResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Optional;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
 
 @Service
 @AllArgsConstructor
@@ -20,7 +23,7 @@ public class BookService {
 
     private final CheckoutRepository checkoutRepository;
 
-    public Book checkoutBook (String userEmail, Long bookId) throws Exception {
+    public Book checkoutBook(String userEmail, Long bookId) throws Exception {
         Optional<Book> book = bookRepository.findById(bookId);
 
         Checkout validateCheckout = checkoutRepository.findByUserEmailAndBookId(userEmail, bookId);
@@ -32,10 +35,10 @@ public class BookService {
         bookRepository.save(book.get());
 
         Checkout checkout = new Checkout(
-                userEmail,
-                LocalDate.now().toString(),
-                LocalDate.now().plusDays(7).toString(),
-                book.get().getId()
+         userEmail,
+         LocalDate.now().toString(),
+         LocalDate.now().plusDays(7).toString(),
+         book.get().getId()
         );
 
         checkoutRepository.save(checkout);
@@ -50,5 +53,33 @@ public class BookService {
 
     public int currentLoansCount(String userEmail) {
         return checkoutRepository.findBooksByUserEmail(userEmail).size();
+    }
+
+    public List<ShelfCurrentLoansResponse> currentLoans(String userEmail) throws Exception {
+        List<ShelfCurrentLoansResponse> shelfCurrentLoansResponses = new ArrayList<>();
+
+        List<Checkout> checkoutList = checkoutRepository.findBooksByUserEmail(userEmail);
+
+        Map<Long, Checkout> checkoutMap = new HashMap<>();
+        for (Checkout checkout : checkoutList) {
+            checkoutMap.put(checkout.getBookId(), checkout);
+        }
+
+        List<Book> books = bookRepository.findBooksByBookIds(new ArrayList<>(checkoutMap.keySet()));
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate currentDate = LocalDate.now();
+
+        for (Book book : books) {
+            Checkout checkout = checkoutMap.get(book.getId());
+
+            if (checkout != null) {
+                LocalDate returnDate = LocalDate.parse(checkout.getReturnDate(), formatter);
+                long differenceInDays = ChronoUnit.DAYS.between(currentDate, returnDate);
+
+                shelfCurrentLoansResponses.add(new ShelfCurrentLoansResponse(book, (int) differenceInDays));
+            }
+        }
+        return shelfCurrentLoansResponses;
     }
 }


### PR DESCRIPTION
1. 사용자의 이메일 주소와 일치하는 엔티티 목록을 검색
2. Map을 이용해 checkout의 BookId를 Key로 Key와 해당 엔티티를 저장
3. Checkout의 Key값과 일치하는 Book을 가져옴.
4. Book리스트를 반복하면서 book의 id와 일치하는 checkoutMap의 value를 가져옴
5. 가져온 value가 null이 아니라면, 대출 날짜와 반환날짜를 반환해줌.
6. 현재는 반환되지 않은 대출만 반환함.