### PR TITLE
Feautre/#84 결제 내역 구현하기

### DIFF
--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PurchaseController.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Controller/PurchaseController.java
@@ -1,0 +1,45 @@
+package com.reactlibraryproject.springbootlibrary.Controller;
+
+import com.reactlibraryproject.springbootlibrary.RequestModels.AddPurchaseRequest;
+import com.reactlibraryproject.springbootlibrary.RequestModels.SuccessPurchaseRequest;
+import com.reactlibraryproject.springbootlibrary.Service.PurchaseService;
+import com.reactlibraryproject.springbootlibrary.Utils.ExtractJWT;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@CrossOrigin("https://localhost:3000")
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/purchase")
+@Tag(name = "결제", description = "결제 API")
+public class PurchaseController {
+
+    private PurchaseService purchaseService;
+
+    @Operation(summary = "결제 승인 전 DB에 추가")
+    @PostMapping("/secure")
+    public void purchaseHistory(@RequestHeader(value = "Authorization") String token,
+                                @RequestBody List<AddPurchaseRequest> purchaseRequests) throws Exception {
+        String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
+        purchaseService.addPurchaseHistory(userEmail, purchaseRequests);
+    }
+
+    @Operation(summary = "결제 승인 전 오류시 DB에서 삭제")
+    @DeleteMapping("/secure/delete/fail")
+    public void deleteFailPurchase(@RequestHeader(value = "Authorization") String token) throws Exception {
+        String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
+        purchaseService.deleteFailPurchase(userEmail);
+    }
+
+    @Operation(summary = "결제 승인후 결제 내역 update")
+    @PutMapping("/secure/update")
+    public void successPurchaseUpdate(@RequestHeader(value = "Authorization") String token,
+                                @RequestBody SuccessPurchaseRequest purchaseRequests) throws Exception {
+        String userEmail = ExtractJWT.payloadJWTExtraction(token, "\"sub\"");
+        purchaseService.successPurchaseUpdate(userEmail, purchaseRequests);
+    }
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/DAO/PurchaseHistoryRepository.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/DAO/PurchaseHistoryRepository.java
@@ -1,0 +1,20 @@
+package com.reactlibraryproject.springbootlibrary.DAO;
+
+import com.reactlibraryproject.springbootlibrary.Entity.PurchaseHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@RepositoryRestResource(path = "purchase-history")
+public interface PurchaseHistoryRepository extends JpaRepository<PurchaseHistory, Long> {
+
+    PurchaseHistory findByUserEmail(String userEmail);
+
+    List<PurchaseHistory> findPurchaseByUserEmail(String userEmail);
+
+    List<PurchaseHistory> findByUserEmailAndPaymentKey(
+     @RequestParam("email") String userEmail
+    ,@RequestParam("paymentKey") String paymentKey);
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Entity/PurchaseHistory.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Entity/PurchaseHistory.java
@@ -1,0 +1,45 @@
+package com.reactlibraryproject.springbootlibrary.Entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "purchase_history")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PurchaseHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    private String userEmail;
+
+    private String title;
+
+    private String author;
+
+    private String category;
+
+    private String img;
+
+    private String publisher;
+
+    private int amount;
+
+    private int price;
+
+    private String paymentKey;
+
+    private String purchaseDate;
+
+    private String orderId;
+
+    private String status;
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/PurchaseHistoryResponse.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/ReponseModels/PurchaseHistoryResponse.java
@@ -1,0 +1,18 @@
+package com.reactlibraryproject.springbootlibrary.ReponseModels;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PurchaseHistoryResponse {
+
+    private String paymentKey;
+
+    private String orderName;
+
+    private int totalPrice;
+
+    private String purchaseDate;
+
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/RequestModels/AddPurchaseRequest.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/RequestModels/AddPurchaseRequest.java
@@ -1,0 +1,13 @@
+package com.reactlibraryproject.springbootlibrary.RequestModels;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AddPurchaseRequest {
+
+    private Long bookId;
+    private int amount;
+
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/RequestModels/SuccessPurchaseRequest.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/RequestModels/SuccessPurchaseRequest.java
@@ -1,0 +1,13 @@
+package com.reactlibraryproject.springbootlibrary.RequestModels;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SuccessPurchaseRequest {
+    private String paymentKey;
+    private String orderId;
+    private String purchaseDate;
+    private String status;
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Service/PurchaseService.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/Service/PurchaseService.java
@@ -1,0 +1,90 @@
+package com.reactlibraryproject.springbootlibrary.Service;
+
+import com.reactlibraryproject.springbootlibrary.DAO.BookRepository;
+import com.reactlibraryproject.springbootlibrary.DAO.PurchaseHistoryRepository;
+import com.reactlibraryproject.springbootlibrary.Entity.Book;
+import com.reactlibraryproject.springbootlibrary.Entity.PurchaseHistory;
+import com.reactlibraryproject.springbootlibrary.ReponseModels.PurchaseHistoryResponse;
+import com.reactlibraryproject.springbootlibrary.RequestModels.AddPurchaseRequest;
+import com.reactlibraryproject.springbootlibrary.RequestModels.SuccessPurchaseRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@AllArgsConstructor
+public class PurchaseService {
+
+    private final PurchaseHistoryRepository purchaseHistoryRepository;
+    private final BookRepository bookRepository;
+
+    public List<PurchaseHistoryResponse> purchaseHistories(String userEmail) throws Exception {
+        List<PurchaseHistory> purchaseHistory = purchaseHistoryRepository.findPurchaseByUserEmail(userEmail);
+
+        if (purchaseHistory.isEmpty()) {
+            throw new Exception("The user's payment history does not exist.");
+        }
+
+        Map<String, List<PurchaseHistory>> purchaseHistoryMap = purchaseHistory.stream()
+         .collect(Collectors.groupingBy(PurchaseHistory::getPaymentKey));
+
+        return purchaseHistoryMap.entrySet().stream()
+         .map(entry -> {
+             List<PurchaseHistory> purchaseHistories = entry.getValue();
+             String orderName = purchaseHistories.get(0).getTitle();
+             int totalPrice = purchaseHistories.stream().mapToInt(PurchaseHistory::getPrice).sum();
+             String purchaseDate = purchaseHistories.get(0).getPurchaseDate();
+             if (purchaseHistories.size() > 1) {
+                 orderName = orderName + "외" + purchaseHistories.size() + "건";
+             }
+             return new PurchaseHistoryResponse(entry.getKey(), orderName, totalPrice, purchaseDate);
+         })
+         .collect(Collectors.toList());
+    }
+    public void addPurchaseHistory(String userEmail, List<AddPurchaseRequest> purchaseRequests) throws Exception {
+        for(AddPurchaseRequest purchaseRequest : purchaseRequests) {
+            Optional<Book> findedBook = bookRepository.findById(purchaseRequest.getBookId());
+            if (findedBook.isEmpty()) {
+                throw new Exception("Book does not exist");
+            }
+            PurchaseHistory saveHistory = PurchaseHistory.builder()
+             .userEmail(userEmail)
+             .title(findedBook.get().getTitle())
+             .author(findedBook.get().getAuthor())
+             .category(findedBook.get().getCategory())
+             .img(findedBook.get().getImg())
+             .publisher(findedBook.get().getPublisher())
+             .amount(purchaseRequest.getAmount())
+             .price(findedBook.get().getPrice() * purchaseRequest.getAmount())
+             .build();
+            purchaseHistoryRepository.save(saveHistory);
+        }
+    }
+
+    public void deleteFailPurchase(String userEmail) {
+        List<PurchaseHistory> nullHistory = purchaseHistoryRepository.findPurchaseByUserEmail(userEmail);
+        for (PurchaseHistory nullValue : nullHistory) {
+            if (nullValue.getStatus() == null) {
+                purchaseHistoryRepository.delete(nullValue);
+            }
+        }
+    }
+
+    public void successPurchaseUpdate(String userEmail, SuccessPurchaseRequest successPurchaseRequest){
+        System.out.println(successPurchaseRequest);
+        List<PurchaseHistory> waitHistory = purchaseHistoryRepository.findPurchaseByUserEmail(userEmail);
+        for (PurchaseHistory waitedHistory : waitHistory) {
+            if (waitedHistory.getStatus() == null && successPurchaseRequest.getStatus() != null) {
+                waitedHistory.setPaymentKey(successPurchaseRequest.getPaymentKey());
+                waitedHistory.setOrderId(successPurchaseRequest.getOrderId());
+                waitedHistory.setPurchaseDate(successPurchaseRequest.getPurchaseDate());
+                waitedHistory.setStatus(successPurchaseRequest.getStatus());
+                purchaseHistoryRepository.save(waitedHistory);
+            }
+        }
+    }
+}


### PR DESCRIPTION
구매 관련 저장 로직 구현
`PurchaseHistoryResponse` 결제 내역 응답 모델
`AddPurchaseRequest` 결제 내역 추가할때, 요청 모델
`SuccessPurchaseRequest` 결제 승인 후 결제 내역 업데이트 요청모델
`PurchaseService` 결제 관련 메소드
- `purchasHistoires` 결제 내역 조회
- `addPurchaseHistory` 결제 하기 눌렀을때, 결제 내역에 추가
- `deleteFailPurchase` 결제 오류 시 결제 내역 삭제
- `successPurchaseUpdate` 결제 승인시 결제 내역 업데이트

`PurchaseController` 결제 API

`Purchasehistory` 결제 내역 entity