### PR TITLE
Feature/#106-Custom-Exception

### DIFF
--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/AlreadyCheckedOutException.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/AlreadyCheckedOutException.java
@@ -1,0 +1,7 @@
+package com.reactlibraryproject.springbootlibrary.CustomExceptions;
+
+public class AlreadyCheckedOutException extends RuntimeException {
+  public AlreadyCheckedOutException() {
+    super("이미 대여한 책입니다.");
+  }
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/BookNotFoundException.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/BookNotFoundException.java
@@ -1,8 +1,8 @@
 package com.reactlibraryproject.springbootlibrary.CustomExceptions;
 
-public class BookNotFoundException extends RuntimeException{
+public class BookNotFoundException extends RuntimeException {
 
-    public BookNotFoundException() {
-        super("존재하지 않는 책입니다.");
-    }
+  public BookNotFoundException() {
+    super("존재하지 않는 책입니다.");
+  }
 }

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/CopiesAvailableException.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/CopiesAvailableException.java
@@ -1,0 +1,7 @@
+package com.reactlibraryproject.springbootlibrary.CustomExceptions;
+
+public class CopiesAvailableException extends RuntimeException {
+  public CopiesAvailableException() {
+    super("대여 불가능한 책입니다. 대여 가능한 권 수가 없습니다.");
+  }
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/NotCheckedOutException.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/NotCheckedOutException.java
@@ -1,0 +1,7 @@
+package com.reactlibraryproject.springbootlibrary.CustomExceptions;
+
+public class NotCheckedOutException extends RuntimeException {
+  public NotCheckedOutException() {
+    super("유저가 대여하지 않은 책입니다.");
+  }
+}


### PR DESCRIPTION
사용자 정의의 예외처리 코드를 작성했다.

`AlreadyCheckedOutException` - 이미 대여한 경우
`BookNotFoundException` - DB에서 책을 찾을 수 없는 경우
`CopiesAvaliableException` - 대여 가능 수 혹은 대여 중인 수가 0보다 작은 경우 `NotCheckedOutExecption` - 유저가 대여하지 않은 책인 경우. => 대여된 책에 대한 기능을 실행할때 사용함.