### PR TITLE
Feature/#111-tossPaymentService-Exception

### DIFF
--- a/Backend/spring-boot-library/build.gradle
+++ b/Backend/spring-boot-library/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'com.okta.spring:okta-spring-boot-starter:2.1.6'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.json:json:20230227'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/DifferentAmountRequestException.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/DifferentAmountRequestException.java
@@ -1,0 +1,7 @@
+package com.reactlibraryproject.springbootlibrary.CustomExceptions;
+
+public class DifferentAmountRequestException extends RuntimeException{
+    public DifferentAmountRequestException() {
+        super("결제 요청된 금액이 다릅니다.");
+    }
+}

--- a/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/PaymentResponseException.java
+++ b/Backend/spring-boot-library/src/main/java/com/reactlibraryproject/springbootlibrary/CustomExceptions/PaymentResponseException.java
@@ -1,0 +1,14 @@
+package com.reactlibraryproject.springbootlibrary.CustomExceptions;
+
+import org.json.JSONObject;import java.net.http.HttpResponse;
+
+public class PaymentResponseException extends RuntimeException {
+
+  public PaymentResponseException(HttpResponse<String> jsonResponse) {
+    super(getMessageFromJson(jsonResponse));
+  }
+  private static String getMessageFromJson(HttpResponse<String>  jsonResponse) {
+    JSONObject jsonObject = new JSONObject(jsonResponse);
+    return jsonResponse.statusCode() + " - " + jsonObject.getString("message");
+  }
+}


### PR DESCRIPTION
`PaymentResponseException` 결제 승인 API 호출시 생기는 오류 코드 + 메세지를 throw 해주는 사용자 정의 Exception

`DifferentAmountRequestException` 결제 대기 중이었던 내역의 결제 금액과 요청으로 들어온 결제 금액이 다르면 throw 하는 사용자 정의 Exception

+ Json의 값을 추출할 수 있는 org.json 디펜던시 추가
https://mvnrepository.com/artifact/org.json/json/20230227